### PR TITLE
Fix git status and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,14 @@ Installing it is relatively simple, you just need to follow these steps:
 
 ```shell
 git clone https://github.com/neko-night/zsh
-
-cp nekonight.zsh-theme ~/.oh-my-zsh/themes
+cp zsh/nekonight.zsh-theme ~/.oh-my-zsh/themes
 ```
+``
 
-then open your zshrc file and type:
+then run the following command to set theme:
 
-```zsh 
-ZSH_THEME=nekonight
-```
-
-and then save and exit the file and type
-
-```zsh 
-source ~/.zshrc 
+```zsh
+omz theme set nekonight
 ```
 
 And that's it, ready to use, your terminal will look like this

--- a/nekonight.zsh-theme
+++ b/nekonight.zsh-theme
@@ -11,16 +11,14 @@ icon_start="╭─"
 icon_user=" 🐱 %B%F{yellow}%n%f%b"
 icon_host=" at 🐱 %B%F{cyan}%m%f%b"
 icon_directory=" in 🐱 %B%F{magenta}%~%f%b"
-icon_branch=" on (🐱 $(git_prompt_info))"
 icon_end="╰─%Bλ%b"
 
 function git_prompt_info() {
   local branch_name=$(git symbolic-ref --short HEAD 2>/dev/null)
-  local git_status=""
   if [[ -n $branch_name ]]; then
-    git_status="$branch_name $(scm_git_status)"
+    local git_status="$branch_name $(scm_git_status)"
+    echo -n " on (🐱 $git_status)"
   fi
-  echo -n "$git_status"
 }
 
 function scm_git_status() {
@@ -32,5 +30,5 @@ function scm_git_status() {
   echo -n "$git_status"
 }
 
-PROMPT="${icon_start}${icon_user}${icon_host}${icon_directory}${icon_branch}
-${icon_end}"
+PROMPT='${icon_start}${icon_user}${icon_host}${icon_directory}$(git_prompt_info)
+${icon_end}'

--- a/nekonight_moon.zsh-theme
+++ b/nekonight_moon.zsh-theme
@@ -11,16 +11,14 @@ icon_start="╭─"
 icon_user=" 🌙 %B%F{yellow}%n%f%b"
 icon_host=" at 🌙 %B%F{cyan}%m%f%b"
 icon_directory=" in 🌙 %B%F{magenta}%~%f%b"
-icon_branch=" on (🌙 $(git_prompt_info))"
 icon_end="╰─%Bλ%b"
 
 function git_prompt_info() {
   local branch_name=$(git symbolic-ref --short HEAD 2>/dev/null)
-  local git_status=""
   if [[ -n $branch_name ]]; then
-    git_status="$branch_name $(scm_git_status)"
+    local git_status="$branch_name $(scm_git_status)"
+    echo -n " on (🌙 $git_status)"
   fi
-  echo -n "$git_status"
 }
 
 function scm_git_status() {
@@ -32,5 +30,5 @@ function scm_git_status() {
   echo -n "$git_status"
 }
 
-PROMPT="${icon_start}${icon_user}${icon_host}${icon_directory}${icon_branch}
-${icon_end}"
+PROMPT='${icon_start}${icon_user}${icon_host}${icon_directory}$(git_prompt_info)
+${icon_end}'


### PR DESCRIPTION
In this PR I've fixed issues on updating status of a git repository after zsh plugin is loaded, it was checking only one time if it is inside a repo and it was at zsh initialization.
I've fixed some mistakes on README.md, make use of "omz" tool and made git status get out if not in a git repo.